### PR TITLE
Only animate capacity indicator on value change

### DIFF
--- a/src/components/BccCapacityIndicator/BccCapacityIndicator.spec.ts
+++ b/src/components/BccCapacityIndicator/BccCapacityIndicator.spec.ts
@@ -7,23 +7,25 @@ describe("BccCapacityIndicator", () => {
   const nextTick = () => Promise.resolve();
 
   it("shows the remaining capacity", async () => {
-    const wrapper = mount(BccCapacityIndicator, { props: { total: 20, used: 14, animate: false } });
+    const wrapper = mount(BccCapacityIndicator, {
+      props: { total: 20, used: 14, animationDuration: 0 },
+    });
     expect(wrapper.text()).toBe("6");
 
-    wrapper.setProps({ used: 6 });
+    wrapper.setProps({ used: 18 });
     await nextTick();
-    expect(wrapper.text()).toBe("14");
+    expect(wrapper.text()).toBe("2");
 
     expect(wrapper.html()).toMatchSnapshot();
   });
 
   it("shows all capacity without the used prop", async () => {
-    const wrapper = mount(BccCapacityIndicator, { props: { total: 42, animate: false } });
+    const wrapper = mount(BccCapacityIndicator, { props: { total: 42, animationDuration: 0 } });
     expect(wrapper.text()).toBe("42");
   });
 
   it("shows an icon if the capacity is infinite", async () => {
-    const wrapper = mount(BccCapacityIndicator, { props: { total: -1, animate: false } });
+    const wrapper = mount(BccCapacityIndicator, { props: { total: -1, animationDuration: 0 } });
     expect(wrapper.html()).toContain("<path");
     expect(wrapper.html()).toMatchSnapshot();
   });

--- a/src/components/BccCapacityIndicator/BccCapacityIndicator.stories.ts
+++ b/src/components/BccCapacityIndicator/BccCapacityIndicator.stories.ts
@@ -100,13 +100,13 @@ export const AlternativeContext: StoryFn<typeof BccCapacityIndicator> = () => ({
   components: { BccCapacityIndicator },
   template: `
   <div class="flex items-start gap-x-2 bg-primary p-4 rounded" data-context="alternative">
-      <BccCapacityIndicator animate :total="42" />
-      <BccCapacityIndicator animate :total="200" :used="1" />
-      <BccCapacityIndicator animate :total="20" :used="6" />
-      <BccCapacityIndicator animate :total="20" :used="18" />
-      <BccCapacityIndicator animate :total="20" :used="20" />
-      <BccCapacityIndicator animate :total="0" :used="0" />
-      <BccCapacityIndicator animate :total="-1" />
+      <BccCapacityIndicator :total="42" />
+      <BccCapacityIndicator :total="200" :used="1" />
+      <BccCapacityIndicator :total="20" :used="6" />
+      <BccCapacityIndicator :total="20" :used="18" />
+      <BccCapacityIndicator :total="20" :used="20" />
+      <BccCapacityIndicator :total="0" :used="0" />
+      <BccCapacityIndicator :total="-1" />
     </div>
   `,
 });

--- a/src/components/BccCapacityIndicator/BccCapacityIndicator.stories.ts
+++ b/src/components/BccCapacityIndicator/BccCapacityIndicator.stories.ts
@@ -15,13 +15,13 @@ export default {
     used: {
       description: "How much from the total capacity is not available",
     },
-    animate: {
-      description: "If the indicator should animate on display or not",
-    },
     size: {
       description: "The size of component",
       options: ["base", "lg"],
       control: { type: "radio" },
+    },
+    animationDuration: {
+      description: "How long the animation in `ms` is when the `used` prop is updated",
     },
   },
 } as Meta<typeof BccCapacityIndicator>;
@@ -40,8 +40,8 @@ export const Example = Template.bind({});
 Example.args = {
   total: 20,
   used: 14,
-  animate: false,
   size: "base",
+  animationDuration: 1000,
 };
 
 /**
@@ -58,24 +58,6 @@ export const State: StoryFn<typeof BccCapacityIndicator> = () => ({
       <BccCapacityIndicator :total="20" :used="20" />
       <BccCapacityIndicator :total="0" :used="0" />
       <BccCapacityIndicator :total="-1" />
-    </div>
-  `,
-});
-
-/**
- * Setting the `animate` prop to `true` will animate the indicator to its current value when it's first rendered
- */
-export const Animated: StoryFn<typeof BccCapacityIndicator> = () => ({
-  components: { BccCapacityIndicator },
-  template: `
-    <div class="flex items-center space-x-4">
-      <BccCapacityIndicator animate :total="42" />
-      <BccCapacityIndicator animate :total="200" :used="1" />
-      <BccCapacityIndicator animate :total="20" :used="6" />
-      <BccCapacityIndicator animate :total="20" :used="18" />
-      <BccCapacityIndicator animate :total="20" :used="20" />
-      <BccCapacityIndicator animate :total="0" :used="0" />
-      <BccCapacityIndicator animate :total="-1" />
     </div>
   `,
 });

--- a/src/components/BccCapacityIndicator/BccCapacityIndicator.vue
+++ b/src/components/BccCapacityIndicator/BccCapacityIndicator.vue
@@ -7,29 +7,33 @@ const props = withDefaults(
     // -1 = Infinity
     total: number;
     used?: number;
-    animate?: boolean;
     size?: "base" | "lg";
+    animationDuration?: number;
   }>(),
   {
     used: 0,
-    animate: false,
     size: "base",
+    animationDuration: 1000,
   }
 );
 
-const duration = props.animate ? 1000 : 0;
+const { value: valueUsed } = useAnimatedNumber(
+  toRef(props, "used"),
+  props.used,
+  props.animationDuration
+);
 
-const { value: valueUsed } = useAnimatedNumber(toRef(props, "used"), 0, duration);
+const percentage = computed(() => {
+  if (props.total === -1) return -1;
+  if (props.used > props.total || props.used === props.total) return 100;
+  if (props.total > 0) return (props.used / props.total) * 100;
+  return 0;
+});
 
 const { value: progress } = useAnimatedNumber(
-  computed(() => {
-    if (props.total === -1) return -1;
-    if (props.used > props.total || props.used === props.total) return 100;
-    if (props.total > 0) return (props.used / props.total) * 100;
-    return 0;
-  }),
-  0,
-  duration
+  percentage,
+  percentage.value,
+  props.animationDuration.value
 );
 
 const dashArray = Math.PI * 18 * 2;

--- a/src/components/BccCapacityIndicator/BccCapacityIndicator.vue
+++ b/src/components/BccCapacityIndicator/BccCapacityIndicator.vue
@@ -33,7 +33,7 @@ const percentage = computed(() => {
 const { value: progress } = useAnimatedNumber(
   percentage,
   percentage.value,
-  props.animationDuration.value
+  props.animationDuration
 );
 
 const dashArray = Math.PI * 18 * 2;

--- a/src/components/BccCapacityIndicator/__snapshots__/BccCapacityIndicator.spec.ts.snap
+++ b/src/components/BccCapacityIndicator/__snapshots__/BccCapacityIndicator.spec.ts.snap
@@ -9,8 +9,8 @@ exports[`BccCapacityIndicator > shows an icon if the capacity is infinite 1`] = 
 `;
 
 exports[`BccCapacityIndicator > shows the remaining capacity 1`] = `
-"<svg width=\\"2em\\" height=\\"2em\\" viewBox=\\"0 0 40 40\\" class=\\"bcc-capacity-indicator bcc-capacity-indicator-open\\">
+"<svg width=\\"2em\\" height=\\"2em\\" viewBox=\\"0 0 40 40\\" class=\\"bcc-capacity-indicator bcc-capacity-indicator-warning\\">
   <circle cx=\\"20\\" cy=\\"20\\" r=\\"18\\" fill=\\"none\\" stroke-width=\\"2\\" stroke=\\"currentColor\\"></circle>
-  <circle cx=\\"20\\" cy=\\"20\\" r=\\"18\\" fill=\\"none\\" stroke-width=\\"2\\" stroke-dasharray=\\"113.09733552923255\\" stroke-dashoffset=\\"79.16813487046278\\" stroke=\\"currentColor\\" transform=\\"rotate(-90 20 20)\\" class=\\"bcc-capacity-indicator-circle-used\\"></circle><text text-anchor=\\"middle\\" x=\\"20\\" y=\\"25\\" font-size=\\"14\\" font-weight=\\"600\\" fill=\\"currentColor\\" class=\\"bcc-capacity-indicator-text\\">14</text>
+  <circle cx=\\"20\\" cy=\\"20\\" r=\\"18\\" fill=\\"none\\" stroke-width=\\"2\\" stroke-dasharray=\\"113.09733552923255\\" stroke-dashoffset=\\"33.929200658769766\\" stroke=\\"currentColor\\" transform=\\"rotate(-90 20 20)\\" class=\\"bcc-capacity-indicator-circle-used\\"></circle><text text-anchor=\\"middle\\" x=\\"20\\" y=\\"25\\" font-size=\\"14\\" font-weight=\\"600\\" fill=\\"currentColor\\" class=\\"bcc-capacity-indicator-text\\">2</text>
 </svg>"
 `;

--- a/src/components/BccCapacityIndicator/__snapshots__/BccCapacityIndicator.spec.ts.snap
+++ b/src/components/BccCapacityIndicator/__snapshots__/BccCapacityIndicator.spec.ts.snap
@@ -11,6 +11,6 @@ exports[`BccCapacityIndicator > shows an icon if the capacity is infinite 1`] = 
 exports[`BccCapacityIndicator > shows the remaining capacity 1`] = `
 "<svg width=\\"2em\\" height=\\"2em\\" viewBox=\\"0 0 40 40\\" class=\\"bcc-capacity-indicator bcc-capacity-indicator-warning\\">
   <circle cx=\\"20\\" cy=\\"20\\" r=\\"18\\" fill=\\"none\\" stroke-width=\\"2\\" stroke=\\"currentColor\\"></circle>
-  <circle cx=\\"20\\" cy=\\"20\\" r=\\"18\\" fill=\\"none\\" stroke-width=\\"2\\" stroke-dasharray=\\"113.09733552923255\\" stroke-dashoffset=\\"33.929200658769766\\" stroke=\\"currentColor\\" transform=\\"rotate(-90 20 20)\\" class=\\"bcc-capacity-indicator-circle-used\\"></circle><text text-anchor=\\"middle\\" x=\\"20\\" y=\\"25\\" font-size=\\"14\\" font-weight=\\"600\\" fill=\\"currentColor\\" class=\\"bcc-capacity-indicator-text\\">2</text>
+  <circle cx=\\"20\\" cy=\\"20\\" r=\\"18\\" fill=\\"none\\" stroke-width=\\"2\\" stroke-dasharray=\\"113.09733552923255\\" stroke-dashoffset=\\"11.309733552923255\\" stroke=\\"currentColor\\" transform=\\"rotate(-90 20 20)\\" class=\\"bcc-capacity-indicator-circle-used\\"></circle><text text-anchor=\\"middle\\" x=\\"20\\" y=\\"25\\" font-size=\\"14\\" font-weight=\\"600\\" fill=\\"currentColor\\" class=\\"bcc-capacity-indicator-text\\">2</text>
 </svg>"
 `;


### PR DESCRIPTION
Don't animate the capacity indicator when it renders, but only when the `used` value updates.

Removes the `animate` prop as it no longer seems necessary. Adds an `animationDuration` prop primarily to make testing easier.

Closes #125
