### PR TITLE
Don't render body if title and content are empty

### DIFF
--- a/src/components/BccModal/BccModal.css
+++ b/src/components/BccModal/BccModal.css
@@ -16,8 +16,8 @@
     }
 
     /* Header */
-    .bcc-modal-header {
-        @apply border-b border-on-primary pb-5;
+    .bcc-modal-header + .bcc-modal-body {
+        @apply border-t border-on-primary pt-5;
     }
 
     /* Body */

--- a/src/components/BccModal/BccModal.vue
+++ b/src/components/BccModal/BccModal.vue
@@ -57,7 +57,7 @@ const showCloseButton = computed(() => props.closeButton && !slots.header);
                 <slot name="header" />
               </div>
 
-              <div class="bcc-modal-body">
+              <div class="bcc-modal-body" v-if="title || showCloseButton || slots.default">
                 <div class="bcc-modal-title" v-if="title || showCloseButton">
                   <DialogTitle as="h3">{{ title }}</DialogTitle>
                   <button


### PR DESCRIPTION
Fixes a small inconsistency where if both the title and default slot are empty, still a border with padding would be render between the header actions.