### PR TITLE
Make input clearable

### DIFF
--- a/.storybook/preview.cjs
+++ b/.storybook/preview.cjs
@@ -9,3 +9,16 @@ export const parameters = {
     },
   },
 }
+
+
+const preview = {
+  parameters: {
+    options: {
+      storySort: {
+        order: ['Forms', 'Components', '*'],
+      },
+    },
+  },
+};
+
+export default preview;

--- a/.storybook/preview.cjs
+++ b/.storybook/preview.cjs
@@ -15,7 +15,7 @@ const preview = {
   parameters: {
     options: {
       storySort: {
-        order: ['Forms', 'Components', '*'],
+        order: ['Introduction', 'Forms', 'Components', '*'],
       },
     },
   },

--- a/src/components/BccButton/BccButton.stories.ts
+++ b/src/components/BccButton/BccButton.stories.ts
@@ -4,7 +4,7 @@ import { SearchIcon, ChevronRightIcon, ChevronLeftIcon } from "@bcc-code/icons-v
 import type { Meta, StoryFn } from "@storybook/vue3";
 
 export default {
-  title: "Components/BccButton",
+  title: "Forms/BccButton",
   component: BccButton,
   argTypes: {
     context: {

--- a/src/components/BccCheckbox/BccCheckbox.stories.ts
+++ b/src/components/BccCheckbox/BccCheckbox.stories.ts
@@ -6,7 +6,7 @@ import type { Meta, StoryFn } from "@storybook/vue3";
  * A checkbox input conforming to the design system styles
  */
 export default {
-  title: "Components/BccCheckbox",
+  title: "Forms/BccCheckbox",
   component: BccCheckbox,
   argTypes: {},
 } as Meta<typeof BccCheckbox>;

--- a/src/components/BccInput/BccInput.css
+++ b/src/components/BccInput/BccInput.css
@@ -1,6 +1,6 @@
 @layer components {
     .bcc-input {
-        @apply w-full h-10 px-4 py-2 text-body-small rounded-lg text-primary bg-primary border border-on-primary focus:outline-1 focus:outline-emphasis;
+        @apply w-full flex items-center h-10 px-4 py-2 text-body-small rounded-lg text-primary bg-primary border border-on-primary focus:outline-1 focus:outline-emphasis;
         @apply placeholder:text-tertiary;
         @apply disabled:bg-secondary disabled:text-tertiary disabled:cursor-not-allowed;
     }
@@ -14,7 +14,10 @@
     }
 
     /* Size */
-    .bcc-input-lg > .bcc-input {
+    .bcc-input-sm .bcc-input {
+        @apply h-8 text-body-small py-1;
+    }
+    .bcc-input-lg .bcc-input {
         @apply h-14 text-body-base py-4;
     }
 
@@ -50,6 +53,9 @@
     /* Icon */
     .bcc-input-icon {
         @apply h-4 w-4 text-secondary;
+    }
+    .bcc-input-icon-disabled {
+        @apply text-tertiary;
     }
     .bcc-input-lg .bcc-input-icon {
         @apply h-6 w-6;

--- a/src/components/BccInput/BccInput.css
+++ b/src/components/BccInput/BccInput.css
@@ -68,4 +68,24 @@
     .bcc-input-lg > .bcc-input-with-icon {
         @apply pl-12;
     }
+
+    /* Clear button */
+    .bcc-input-clear-button-wrapper {
+        @apply absolute inset-y-0 right-0 flex items-center pr-3;
+    }
+
+    .bcc-input-clear-button {
+        @apply h-5 w-5 cursor-pointer text-tertiary hover:text-secondary active:text-primary;
+    }
+    
+    .bcc-input-clearable {
+        @apply pr-8;
+    }
+
+    .bcc-input-lg .bcc-input-clear-button {
+        @apply w-6 h-6;
+    }
+    .bcc-input-lg .bcc-input-clearable {
+        @apply pr-10;
+    }
 }

--- a/src/components/BccInput/BccInput.css
+++ b/src/components/BccInput/BccInput.css
@@ -1,6 +1,6 @@
 @layer components {
     .bcc-input {
-        @apply w-full px-4 py-3 text-body-small rounded-lg text-primary bg-primary border border-on-primary focus:outline-2 focus:outline-emphasis;
+        @apply w-full h-10 px-4 py-2 text-body-small rounded-lg text-primary bg-primary border border-on-primary focus:outline-2 focus:outline-emphasis;
         @apply disabled:bg-secondary disabled:text-tertiary disabled:cursor-not-allowed;
     }
 
@@ -14,7 +14,7 @@
 
     /* Size */
     .bcc-input-lg > .bcc-input {
-        @apply text-body-base py-4;
+        @apply h-14 text-body-base py-4;
     }
 
     /* Label */

--- a/src/components/BccInput/BccInput.css
+++ b/src/components/BccInput/BccInput.css
@@ -1,6 +1,7 @@
 @layer components {
     .bcc-input {
-        @apply w-full h-10 px-4 py-2 text-body-small rounded-lg text-primary bg-primary border border-on-primary focus:outline-2 focus:outline-emphasis;
+        @apply w-full h-10 px-4 py-2 text-body-small rounded-lg text-primary bg-primary border border-on-primary focus:outline-1 focus:outline-emphasis;
+        @apply placeholder:text-tertiary;
         @apply disabled:bg-secondary disabled:text-tertiary disabled:cursor-not-allowed;
     }
 
@@ -48,7 +49,7 @@
 
     /* Icon */
     .bcc-input-icon {
-        @apply h-4 w-4 text-tertiary;
+        @apply h-4 w-4 text-secondary;
     }
     .bcc-input-lg .bcc-input-icon {
         @apply h-6 w-6;
@@ -75,7 +76,7 @@
     }
 
     .bcc-input-clear-button {
-        @apply h-5 w-5 cursor-pointer text-tertiary hover:text-secondary active:text-primary;
+        @apply h-5 w-5 cursor-pointer text-primary hover:text-secondary;
     }
     
     .bcc-input-clearable {

--- a/src/components/BccInput/BccInput.spec.ts
+++ b/src/components/BccInput/BccInput.spec.ts
@@ -4,6 +4,14 @@ import { mount } from "@vue/test-utils";
 import BccInput from "./BccInput.vue";
 
 describe("BccInput", () => {
+  it("emits update event on input", async () => {
+    const wrapper = mount(BccInput);
+    await wrapper.find(".bcc-input").setValue("brunstad");
+
+    expect(wrapper.emitted("update:modelValue")?.length).toBe(1);
+    expect(wrapper.emitted("update:modelValue")![0]).toEqual(["brunstad"]);
+  });
+
   it("renders a text from the default slot", () => {
     const wrapper = mount(BccInput, {
       slots: { default: "Test message" },
@@ -50,5 +58,14 @@ describe("BccInput", () => {
   it("passes through non-prop attributes", () => {
     const wrapper = mount(BccInput, { attrs: { autocomplete: true } });
     expect(wrapper.html()).toContain('autocomplete="true"');
+  });
+
+  it("emits events when clearing the input", async () => {
+    const wrapper = mount(BccInput, { props: { modelValue: "Test value", clearable: true } });
+    await wrapper.find(".bcc-input-clear-button").trigger("click");
+
+    expect(wrapper.emitted("update:modelValue")?.length).toBe(1);
+    expect(wrapper.emitted("update:modelValue")![0]).toEqual([""]);
+    expect(wrapper.emitted("clear")?.length).toBe(1);
   });
 });

--- a/src/components/BccInput/BccInput.stories.ts
+++ b/src/components/BccInput/BccInput.stories.ts
@@ -4,7 +4,7 @@ import { SearchIcon } from "@bcc-code/icons-vue";
 import type { Meta, StoryFn } from "@storybook/vue3";
 
 export default {
-  title: "Components/BccInput",
+  title: "Forms/BccInput",
   component: BccInput,
   argTypes: {
     size: {

--- a/src/components/BccInput/BccInput.stories.ts
+++ b/src/components/BccInput/BccInput.stories.ts
@@ -11,6 +11,9 @@ export default {
       options: ["base", "lg"],
       control: { type: "radio" },
     },
+    clearable: {
+      description: "Whether to display an icon button to clear the input",
+    },
     state: {
       description: "Style of the input",
       options: ["default", "error", "success"],
@@ -26,6 +29,9 @@ export default {
       name: "default slot",
       description: "An optional message below the input",
     },
+    value: {
+      description: "For testing purposes in Storybook, use `v-model` normally",
+    },
   },
 } as Meta<typeof BccInput>;
 
@@ -35,7 +41,7 @@ const Template: StoryFn<typeof BccInput> = (args) => ({
     return { args, SearchIcon };
   },
   template: `
-    <BccInput v-bind="args" type="text" value="Example value" :icon="SearchIcon">
+    <BccInput v-bind="args" type="text" v-model="args.value" :icon="SearchIcon" @clear="args.value = ''" class="w-1/4">
       {{ args.slotDefault }}
     </BccInput>
   `,
@@ -48,6 +54,7 @@ export const Example = Template.bind({});
 Example.args = {
   state: "default",
   size: "base",
+  clearable: true,
   disabled: false,
   required: false,
   placeholder: "Example placeholder",
@@ -55,13 +62,20 @@ Example.args = {
   label: "Example label",
   showOptionalLabel: false,
   optionalLabel: "Optional",
+  value: "Example value",
 };
 Example.parameters = {
   docs: {
     source: {
       language: "html",
       code: `
-<BccInput :icon="SearchIcon" label="Example label" placeholder="Example placeholder" v-model="example" />      
+<BccInput
+  :icon="SearchIcon"
+  label="Example label"
+  placeholder="Example placeholder"
+  clearable
+  v-model="example"
+/>      
 `,
     },
   },
@@ -128,6 +142,40 @@ export const WithIcon: StoryFn<typeof BccInput> = () => ({
     </div>
   `,
 });
+
+/**
+ * Set the `clearable` prop to render an icon button on the right to clear the input when there is a value. Will emit both the normal `update:modelValue` event (automatically handled with `v-model`) and a `clear` event if you need to do extra logic when someone clicks the button.
+ */
+export const Clearable = Template.bind({});
+Clearable.args = {
+  state: "default",
+  size: "base",
+  clearable: true,
+  disabled: false,
+  required: false,
+  placeholder: "Find a city...",
+  slotDefault: "",
+  label: "Search",
+  showOptionalLabel: false,
+  optionalLabel: "Optional",
+  value: "Krakow",
+};
+Clearable.parameters = {
+  docs: {
+    source: {
+      language: "html",
+      code: `
+<BccInput
+  :icon="SearchIcon"
+  label="Search"
+  placeholder="Find something..."
+  clearable
+  v-model="search"
+/>
+`,
+    },
+  },
+};
 
 /**
  * Set the `show-optional-label` prop to show a label when the input is not `required`. Control the text for this label with the `optionalLabel` prop, which can be useful for translation.

--- a/src/components/BccInput/BccInput.stories.ts
+++ b/src/components/BccInput/BccInput.stories.ts
@@ -8,7 +8,7 @@ export default {
   component: BccInput,
   argTypes: {
     size: {
-      options: ["base", "lg"],
+      options: ["sm", "base", "lg"],
       control: { type: "radio" },
     },
     clearable: {
@@ -102,12 +102,17 @@ export const State: StoryFn<typeof BccInput> = () => ({
  */
 export const Size: StoryFn<typeof BccInput> = () => ({
   components: { BccInput },
+  setup() {
+    return { SearchIcon };
+  },
   template: `
     <div class="inline-flex flex-col space-y-4">
+      <BccInput size="sm" value="sm" placeholder="Example placeholder" />
+      <BccInput size="sm" value="sm" placeholder="Example placeholder" :icon="SearchIcon" disabled />
       <BccInput value="base" placeholder="Example placeholder" />
-      <BccInput value="base" placeholder="Example placeholder" disabled />
+      <BccInput value="base" placeholder="Example placeholder" :icon="SearchIcon" disabled />
       <BccInput size="lg" value="lg" placeholder="Example placeholder" />
-      <BccInput size="lg" value="lg" placeholder="Example placeholder" disabled />
+      <BccInput size="lg" value="lg" placeholder="Example placeholder" :icon="SearchIcon" disabled />
     </div>
   `,
 });

--- a/src/components/BccInput/BccInput.stories.ts
+++ b/src/components/BccInput/BccInput.stories.ts
@@ -54,7 +54,7 @@ export const Example = Template.bind({});
 Example.args = {
   state: "default",
   size: "base",
-  clearable: true,
+  clearable: false,
   disabled: false,
   required: false,
   placeholder: "Example placeholder",
@@ -73,7 +73,6 @@ Example.parameters = {
   :icon="SearchIcon"
   label="Example label"
   placeholder="Example placeholder"
-  clearable
   v-model="example"
 />      
 `,

--- a/src/components/BccInput/BccInput.vue
+++ b/src/components/BccInput/BccInput.vue
@@ -80,16 +80,17 @@ function clear() {
           'bcc-input-error': state === 'error',
           'bcc-input-success': state === 'success',
           'bcc-input-with-icon': icon,
-          'bcc-input-with-clearable': clearable,
+          'bcc-input-clearable': clearable,
         }"
         :value="modelValue"
         @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
         v-bind="attrsWithoutStyles"
       />
-      <div class="absolute inset-y-0 right-0 flex items-center pr-3" v-if="clearable && modelValue">
+      <div class="bcc-input-clear-button-wrapper" v-if="clearable && modelValue">
+        <span class="sr-only" id="bcc-input-clear-desc">Clear input</span>
         <CloseIcon
-          class="h-5 w-5 cursor-pointer text-tertiary hover:text-secondary active:text-primary"
-          aria-hidden="true"
+          class="bcc-input-clear-button"
+          aria-describedby="bcc-input-clear-desc"
           @click="clear"
         />
       </div>

--- a/src/components/BccInput/BccInput.vue
+++ b/src/components/BccInput/BccInput.vue
@@ -13,7 +13,7 @@ import { CloseIcon } from "@bcc-code/icons-vue";
 type Props = {
   modelValue?: string;
   state?: "default" | "error" | "success";
-  size?: "base" | "lg";
+  size?: "sm" | "base" | "lg";
   icon?: string | Component | Function;
   clearable?: boolean;
   disabled?: boolean;
@@ -65,11 +65,17 @@ function clear() {
     <div
       class="bcc-input-wrapper"
       :class="{
+        'bcc-input-sm': size === 'sm',
         'bcc-input-lg': size === 'lg',
       }"
     >
       <div class="bcc-input-icon-wrapper" v-if="icon">
-        <component :is="icon" class="bcc-input-icon" aria-hidden="true" />
+        <component
+          :is="icon"
+          class="bcc-input-icon"
+          :class="{ 'bcc-input-icon-disabled': disabled }"
+          aria-hidden="true"
+        />
       </div>
       <input
         :id="id"

--- a/src/components/BccInput/BccInput.vue
+++ b/src/components/BccInput/BccInput.vue
@@ -8,12 +8,14 @@ export default {
 import { computed, type Component, type StyleValue } from "vue";
 import { useAttrs } from "vue";
 import { useId } from "../../hooks/use-id";
+import { CloseIcon } from "@bcc-code/icons-vue";
 
 type Props = {
   modelValue?: string;
   state?: "default" | "error" | "success";
   size?: "base" | "lg";
   icon?: string | Component | Function;
+  clearable?: boolean;
   disabled?: boolean;
   label?: string;
   showOptionalLabel?: boolean;
@@ -24,6 +26,7 @@ type Props = {
 const props = withDefaults(defineProps<Props>(), {
   state: "default",
   size: "base",
+  clearable: false,
   disabled: false,
   required: false,
   showOptionalLabel: false,
@@ -32,7 +35,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const id = `bcc-input-${useId()}`;
 
-defineEmits(["update:modelValue"]);
+const emit = defineEmits(["update:modelValue", "clear"]);
 
 const showOptionalLabel = computed(() => props.showOptionalLabel && !props.required);
 
@@ -46,6 +49,11 @@ const attrsWithoutStyles = computed(() => {
   }
   return returnObj;
 });
+
+function clear() {
+  emit("update:modelValue", "");
+  emit("clear");
+}
 </script>
 
 <template>
@@ -72,11 +80,19 @@ const attrsWithoutStyles = computed(() => {
           'bcc-input-error': state === 'error',
           'bcc-input-success': state === 'success',
           'bcc-input-with-icon': icon,
+          'bcc-input-with-clearable': clearable,
         }"
         :value="modelValue"
-        @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+        @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
         v-bind="attrsWithoutStyles"
       />
+      <div class="absolute inset-y-0 right-0 flex items-center pr-3" v-if="clearable && modelValue">
+        <CloseIcon
+          class="h-5 w-5 cursor-pointer text-tertiary hover:text-secondary active:text-primary"
+          aria-hidden="true"
+          @click="clear"
+        />
+      </div>
     </div>
     <span
       v-if="$slots.default"

--- a/src/components/BccInput/__snapshots__/BccInput.spec.ts.snap
+++ b/src/components/BccInput/__snapshots__/BccInput.spec.ts.snap
@@ -1,9 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`BccInput > can render an extra label if the input is optional 1`] = `
-"<div class=\\"bcc-input-container\\"><label class=\\"bcc-input-label\\" for=\\"bcc-input-4\\"><span></span><span class=\\"bcc-input-optional-label\\">Custom optional label</span></label>
+"<div class=\\"bcc-input-container\\"><label class=\\"bcc-input-label\\" for=\\"bcc-input-5\\"><span></span><span class=\\"bcc-input-optional-label\\">Custom optional label</span></label>
   <div class=\\"bcc-input-wrapper\\">
-    <!--v-if--><input id=\\"bcc-input-4\\" class=\\"bcc-input\\">
+    <!--v-if--><input id=\\"bcc-input-5\\" class=\\"bcc-input\\">
+    <!--v-if-->
   </div>
   <!--v-if-->
 </div>"
@@ -13,18 +14,20 @@ exports[`BccInput > does not render a text if the input is both required and opt
 "<div class=\\"bcc-input-container\\">
   <!--v-if-->
   <div class=\\"bcc-input-wrapper\\">
-    <!--v-if--><input id=\\"bcc-input-5\\" required=\\"\\" class=\\"bcc-input\\">
+    <!--v-if--><input id=\\"bcc-input-6\\" required=\\"\\" class=\\"bcc-input\\">
+    <!--v-if-->
   </div>
   <!--v-if-->
 </div>"
 `;
 
 exports[`BccInput > renders a label 1`] = `
-"<div class=\\"bcc-input-container\\"><label class=\\"bcc-input-label\\" for=\\"bcc-input-2\\"><span>Test label</span>
+"<div class=\\"bcc-input-container\\"><label class=\\"bcc-input-label\\" for=\\"bcc-input-3\\"><span>Test label</span>
     <!--v-if-->
   </label>
   <div class=\\"bcc-input-wrapper\\">
-    <!--v-if--><input id=\\"bcc-input-2\\" class=\\"bcc-input\\">
+    <!--v-if--><input id=\\"bcc-input-3\\" class=\\"bcc-input\\">
+    <!--v-if-->
   </div>
   <!--v-if-->
 </div>"
@@ -34,7 +37,8 @@ exports[`BccInput > renders a text from the default slot 1`] = `
 "<div class=\\"bcc-input-container\\">
   <!--v-if-->
   <div class=\\"bcc-input-wrapper\\">
-    <!--v-if--><input id=\\"bcc-input-1\\" class=\\"bcc-input\\">
+    <!--v-if--><input id=\\"bcc-input-2\\" class=\\"bcc-input\\">
+    <!--v-if-->
   </div><span class=\\"bcc-input-message-default\\">Test message</span>
 </div>"
 `;
@@ -43,7 +47,8 @@ exports[`BccInput > renders without a label or optional text 1`] = `
 "<div class=\\"bcc-input-container\\">
   <!--v-if-->
   <div class=\\"bcc-input-wrapper\\">
-    <!--v-if--><input id=\\"bcc-input-3\\" class=\\"bcc-input\\">
+    <!--v-if--><input id=\\"bcc-input-4\\" class=\\"bcc-input\\">
+    <!--v-if-->
   </div>
   <!--v-if-->
 </div>"

--- a/src/components/BccRadio/BccRadio.stories.ts
+++ b/src/components/BccRadio/BccRadio.stories.ts
@@ -6,7 +6,7 @@ import type { Meta, StoryFn } from "@storybook/vue3";
  * A radio input conforming to the design system styles
  */
 export default {
-  title: "Components/BccRadio",
+  title: "Forms/BccRadio",
   component: BccRadio,
   argTypes: {},
 } as Meta<typeof BccRadio>;

--- a/src/components/BccToggle/BccToggle.stories.ts
+++ b/src/components/BccToggle/BccToggle.stories.ts
@@ -3,7 +3,7 @@ import BccToggle from "./BccToggle.vue";
 import type { Meta, StoryFn } from "@storybook/vue3";
 
 export default {
-  title: "Components/BccToggle",
+  title: "Forms/BccToggle",
   component: BccToggle,
   argTypes: {},
 } as Meta<typeof BccToggle>;


### PR DESCRIPTION
Add a `clearable` option to the input to render a button with which the input can be cleared.

Closes #129
