### PR TITLE
Disable padding on tertiary button by default

### DIFF
--- a/src/components/BccButton/BccButton.stories.ts
+++ b/src/components/BccButton/BccButton.stories.ts
@@ -33,9 +33,9 @@ export default {
       options: ["button", "a"],
       control: { type: "radio" },
     },
-    padding: {
+    tertiaryPadding: {
       description:
-        "Remove all vertical and horizontal padding and the set button height for the `tertiary` button",
+        "Whether to include the vertical and horizontal padding and the set button height for the `tertiary` button",
     },
     slotDefault: {
       name: "default slot",
@@ -115,7 +115,7 @@ export const Secondary: StoryFn<typeof BccButton> = () => ({
 });
 
 /**
- * Set the `variant` prop to `tertiary` to render a tertiary button. Set the `padding` prop to `false` to disable any padding and set height to be able to use this button as a link
+ * Set the `variant` prop to `tertiary` to render a tertiary button. Set the `tertiaryPadding` prop to include the normal padding and set height for the button. This is off by default for the tertiary button to enable a more inline look
  */
 export const Tertiary: StoryFn<typeof BccButton> = () => ({
   components: { BccButton },
@@ -128,7 +128,13 @@ export const Tertiary: StoryFn<typeof BccButton> = () => ({
       <BccButton variant="tertiary" size="xl">Tertiary (xl)</BccButton>
     </div>
     <div>
-      <BccButton variant="tertiary" :padding="false">Tertiary (no padding)</BccButton>
+      <div class="flex items-center gap-x-2">
+        <BccButton variant="tertiary" tertiaryPadding size="xs">Tertiary (xs)</BccButton>
+        <BccButton variant="tertiary" tertiaryPadding size="sm">Tertiary (sm)</BccButton>
+        <BccButton variant="tertiary" tertiaryPadding size="base">Tertiary (base)</BccButton>
+        <BccButton variant="tertiary" tertiaryPadding size="lg">Tertiary (lg)</BccButton>
+        <BccButton variant="tertiary" tertiaryPadding size="xl">Tertiary (xl)</BccButton>
+      </div>
     </div>
   `,
 });

--- a/src/components/BccButton/BccButton.vue
+++ b/src/components/BccButton/BccButton.vue
@@ -12,7 +12,7 @@ type Props = {
   center?: boolean;
   rounded?: boolean;
   disabled?: boolean;
-  padding?: boolean;
+  tertiaryPadding?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -24,7 +24,7 @@ const props = withDefaults(defineProps<Props>(), {
   center: true,
   rounded: false,
   disabled: false,
-  padding: true,
+  tertiaryPadding: false,
 });
 
 const slots = useSlots();
@@ -45,7 +45,7 @@ const iconOnly = props.icon !== undefined && !slots.default;
       'bcc-button-primary': variant === 'primary',
       'bcc-button-secondary': variant === 'secondary',
       'bcc-button-tertiary': variant === 'tertiary',
-      'bcc-button-no-padding': !padding,
+      'bcc-button-no-padding': !tertiaryPadding,
       'bcc-button-icon-only': iconOnly,
       'bcc-button-rounded': rounded,
       'bcc-button-center': center,

--- a/src/components/BccTable/BccTable.stories.ts
+++ b/src/components/BccTable/BccTable.stories.ts
@@ -30,7 +30,7 @@ const Template: StoryFn<typeof BccTable> = (args) => ({
         <BccBadge :context="item.status.context">{{ item.status.text }}</BccBadge>
       </template>
       <template #item.actions="{ item }">
-        <BccButton variant="tertiary" size="sm" :padding="false" :icon="ChevronRightIcon" iconRight>Evaluation</BccButton>
+        <BccButton variant="tertiary" size="sm" :icon="ChevronRightIcon" iconRight>Evaluation</BccButton>
       </template>
     </BccTable>
   `,
@@ -123,7 +123,7 @@ Example.parameters = {
     <BccBadge :context="item.status.context">{{ item.status.text }}</BccBadge>
   </template>
   <template #item.actions="{ item }">
-    <BccButton variant="tertiary" size="sm" :padding="false" :icon="ChevronRightIcon" iconRight @click="editItem(item.id")>Evaluation</BccButton>
+    <BccButton variant="tertiary" size="sm" :icon="ChevronRightIcon" iconRight @click="editItem(item.id")>Evaluation</BccButton>
   </template>
 </BccTable>
     `,


### PR DESCRIPTION
\+ rename prop to `tertiaryPadding` to avoid confusion, because it doesn't impact primary/secondary buttons
