### PR TITLE
Disable text selection on button

### DIFF
--- a/src/components/BccButton/BccButton.css
+++ b/src/components/BccButton/BccButton.css
@@ -1,6 +1,6 @@
 @layer components {
     .bcc-button {
-        @apply font-semibold inline-flex items-center tracking-wide border justify-between active:shadow-inner hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-emphasis focus-visible:outline-offset-2;
+        @apply select-none font-semibold inline-flex items-center tracking-wide border justify-between active:shadow-inner hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-emphasis focus-visible:outline-offset-2;
         @apply cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none;
         
         /* Default base size */


### PR DESCRIPTION
Fixes an issue on desktop if you dobble click the button for some reason then the text get selected which looks weird and makes it less readable.
